### PR TITLE
Add cjdns example for routing protocls

### DIFF
--- a/network-device-configuration-example.json
+++ b/network-device-configuration-example.json
@@ -106,6 +106,11 @@
             "name": "batman-adv",
             "version": "2014.3.0",
             "router_id": "de:9f:db:30:c9:c5"
+        },
+        {
+            "name": "cjdns",
+            "version": "c7eed6b14688458e16fab368f68904e530651a30",
+            "router_id": "4upjugvc9rmtw08uy61tg17zm66wtxswxsfbr2z30fc9urtdvnm0.k"
         }
     ],
     "dns": [


### PR DESCRIPTION
I added a bit to the network-device-configuration to show how a cjdns node might be represented.
